### PR TITLE
Fix variable name in _Center_Nozzle macro

### DIFF
--- a/klack-macros.cfg
+++ b/klack-macros.cfg
@@ -669,7 +669,7 @@ gcode:
 gcode:
     {% set travel_feedrate = printer["gcode_macro _User_Variables"].travel_speed * 60 %}
     {% set max_x = printer["gcode_macro _User_Variables"].bed_size_x|float %}
-    {% set max_y = printer["gcode_macro _User_Variables"].bed_size_|float %}
+    {% set max_y = printer["gcode_macro _User_Variables"].bed_size_y|float %}
     _Move_to_Safe_z
     G0 X{max_x/2} Y{max_y/2} F{travel_feedrate}
 


### PR DESCRIPTION
Macro _Center_Nozzle is trying to set max_y to bed_size__ instead of bed_size_y